### PR TITLE
reimplement multi-touch method

### DIFF
--- a/Demo.WindowsPresentation/Windows/MainWindow.xaml
+++ b/Demo.WindowsPresentation/Windows/MainWindow.xaml
@@ -58,7 +58,7 @@
     </Window.Resources>
     <Grid>
         <GroupBox Name="mapgroup"  Header="gmap" Margin="12,7,241,12" VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch">
-            <src:Map x:Name="MainMap" Zoom="13" MaxZoom="24" MinZoom="1" />
+            <src:Map x:Name="MainMap" Zoom="13" MaxZoom="24" MinZoom="1" MultiTouchEnabled="True" />
         </GroupBox>
         <GroupBox HorizontalAlignment="Right" Margin="0,7,186,12" VerticalAlignment="Stretch" Header="Zoom">
             <Grid>

--- a/Demo.WindowsPresentation/Windows/MainWindow.xaml.cs
+++ b/Demo.WindowsPresentation/Windows/MainWindow.xaml.cs
@@ -60,7 +60,7 @@ namespace Demo.WindowsPresentation
          // config map
          MainMap.MapProvider = GMapProviders.OpenStreetMap;
          MainMap.Position = new PointLatLng(54.6961334816182, 25.2985095977783);
-
+         MainMap.TouchEnabled = false;
          //MainMap.ScaleMode = ScaleModes.Dynamic;
 
          // map events


### PR DESCRIPTION
English is not very good, the following is translated with google, if the usage or meaning a little problem, please be more tolerant. The multi-touch function in GMAP.NET.WindowsPresentation is a bit problematic. When using the single-touch function, the initial position of the second click is incorrect. The guess may be that the value in mousedown in Core.BeginDrag(mousedown) is (0,0) because the mouse click position is obtained, and now the initial position of touchdown is needed. I don't know how to use Manipulation to modify. So another touch event was used to complete the multi-touch.Until now,it looks like working well.