### PR TITLE
correct spelling 'Sattelite' to 'Satellite' throughout

### DIFF
--- a/Demo.WindowsMobile/Forms/MainForm.Designer.cs
+++ b/Demo.WindowsMobile/Forms/MainForm.Designer.cs
@@ -236,7 +236,7 @@
           // 
           // menuItem10
           // 
-          this.menuItem10.Text = "Google Sattelite";
+          this.menuItem10.Text = "Google Satellite";
           this.menuItem10.Click += new System.EventHandler(this.menuItem10_Click);
           // 
           // menuItem19

--- a/GMap.NET.Core/GMap.NET.Core.csproj
+++ b/GMap.NET.Core/GMap.NET.Core.csproj
@@ -255,7 +255,7 @@
     <Compile Include="GMap.NET.MapProviders\Lithuania\LithuaniaMapProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\Lithuania\LithuaniaTOP50.cs" />
     <Compile Include="GMap.NET.MapProviders\OpenStreetMap\OpenStreet4UMapProvider.cs" />
-    <Compile Include="GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestSatteliteProvider.cs" />
+    <Compile Include="GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestSatelliteProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestHybridProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestProvider.cs" />
     <Compile Include="GMap.NET.MapProviders\OpenStreetMap\OpenCycleTransportMapProvider.cs" />

--- a/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
@@ -58,7 +58,7 @@ namespace GMap.NET.MapProviders
         public static readonly OpenCycleTransportMapProvider OpenCycleTransportMap = OpenCycleTransportMapProvider.Instance;
 
         public static readonly OpenStreetMapQuestProvider OpenStreetMapQuest = OpenStreetMapQuestProvider.Instance;
-        public static readonly OpenStreetMapQuestSatteliteProvider OpenStreetMapQuestSattelite = OpenStreetMapQuestSatteliteProvider.Instance;
+        public static readonly OpenStreetMapQuestSatelliteProvider OpenStreetMapQuestSatellite = OpenStreetMapQuestSatelliteProvider.Instance;
         public static readonly OpenStreetMapQuestHybridProvider OpenStreetMapQuestHybrid = OpenStreetMapQuestHybridProvider.Instance;
 
         public static readonly OpenSeaMapHybridProvider OpenSeaMapHybrid = OpenSeaMapHybridProvider.Instance;

--- a/GMap.NET.Core/GMap.NET.MapProviders/OpenStreetMap/OpenStreetMapQuestHybridProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/OpenStreetMap/OpenStreetMapQuestHybridProvider.cs
@@ -47,7 +47,7 @@ namespace GMap.NET.MapProviders
          {
             if(overlays == null)
             {
-               overlays = new GMapProvider[] { OpenStreetMapQuestSatteliteProvider.Instance, this };
+               overlays = new GMapProvider[] { OpenStreetMapQuestSatelliteProvider.Instance, this };
             }
             return overlays;
          }

--- a/GMap.NET.Core/GMap.NET.MapProviders/OpenStreetMap/OpenStreetMapQuestSatelliteProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/OpenStreetMap/OpenStreetMapQuestSatelliteProvider.cs
@@ -4,20 +4,20 @@ namespace GMap.NET.MapProviders
    using System;
 
    /// <summary>
-   /// OpenStreetMapQuestSattelite provider - http://wiki.openstreetmap.org/wiki/MapQuest
+   /// OpenStreetMapQuestSatellite provider - http://wiki.openstreetmap.org/wiki/MapQuest
    /// </summary>
-   public class OpenStreetMapQuestSatteliteProvider : OpenStreetMapProviderBase
+   public class OpenStreetMapQuestSatelliteProvider : OpenStreetMapProviderBase
    {
-      public static readonly OpenStreetMapQuestSatteliteProvider Instance;
+      public static readonly OpenStreetMapQuestSatelliteProvider Instance;
 
-      OpenStreetMapQuestSatteliteProvider()
+      OpenStreetMapQuestSatelliteProvider()
       {
          Copyright = string.Format("© MapQuest - Map data ©{0} MapQuest, OpenStreetMap", DateTime.Today.Year);
       }
 
-      static OpenStreetMapQuestSatteliteProvider()
+      static OpenStreetMapQuestSatelliteProvider()
       {
-         Instance = new OpenStreetMapQuestSatteliteProvider();
+         Instance = new OpenStreetMapQuestSatelliteProvider();
       }
 
       #region GMapProvider Members
@@ -31,7 +31,7 @@ namespace GMap.NET.MapProviders
          }
       }
 
-      readonly string name = "OpenStreetMapQuestSattelite";
+      readonly string name = "OpenStreetMapQuestSatellite";
       public override string Name
       {
          get

--- a/GMap.NET.WindowsMobile/GMap.NET.WindowsMobile.csproj
+++ b/GMap.NET.WindowsMobile/GMap.NET.WindowsMobile.csproj
@@ -283,8 +283,8 @@
     <Compile Include="..\GMap.NET.Core\GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestProvider.cs">
       <Link>GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestProvider.cs</Link>
     </Compile>
-    <Compile Include="..\GMap.NET.Core\GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestSatteliteProvider.cs">
-      <Link>GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestSatteliteProvider.cs</Link>
+    <Compile Include="..\GMap.NET.Core\GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestSatelliteProvider.cs">
+      <Link>GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapQuestSatelliteProvider.cs</Link>
     </Compile>
     <Compile Include="..\GMap.NET.Core\GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapSurferProvider.cs">
       <Link>GMap.NET.MapProviders\OpenStreetMap\OpenStreetMapSurferProvider.cs</Link>


### PR DESCRIPTION
Changing the names of things that have already been released can create problems for existing code but it makes it much easier for new users/applications.