### PR TITLE
add capability to create a new map provider at runtime

### DIFF
--- a/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
+++ b/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
@@ -47,6 +47,17 @@ namespace GMap.NET.MapProviders
         {
         }
 
+        /// <summary>
+        /// add a new provider to the list
+        /// </summary>
+        public static GMapProvider AddProvider( GMapProvider p )
+        {
+           list.Add(p);
+           Hash.Add(p.Id, p);
+           DbHash.Add(p.DbId, p);
+           return p;
+        }
+
         public static readonly EmptyProvider EmptyProvider = EmptyProvider.Instance;
 
         public static readonly OpenStreetMapProvider OpenStreetMap = OpenStreetMapProvider.Instance;


### PR DESCRIPTION
This adds an "AddProvider" method to GmapProviders so that a greatmaps client can create and use a customized provider.

See my fork at https://github.com/kd7mrx/greatmaps for modified demo programs that show how this can be used.  Note that the modified demos use a hard-coded URL pointing to a private tile server on my local network.  In a real application, that server base URL might be supplied from an application config file.  The key point is that the custom map provider could be built into the application, not into the Gmap.NET core.
