### PR TITLE
Bugfix for touch panning in WPF

### DIFF
--- a/GMap.NET.Core/GMap.NET.Internals/Core.cs
+++ b/GMap.NET.Core/GMap.NET.Internals/Core.cs
@@ -38,6 +38,7 @@ namespace GMap.NET.Internals
         public GPoint mouseDown;
         public GPoint mouseCurrent;
         public GPoint mouseLastZoom;
+        public GPoint touchCurrent;
 
         public MouseWheelZoomType MouseWheelZoomType = MouseWheelZoomType.MousePositionAndCenter;
         public bool MouseWheelZoomEnabled = true;

--- a/GMap.NET.WindowsPresentation/GMap.NET.WindowsPresentation/GMapControl.cs
+++ b/GMap.NET.WindowsPresentation/GMap.NET.WindowsPresentation/GMapControl.cs
@@ -1931,6 +1931,19 @@
          }
       }
 
+      protected override void OnManipulationStarted(ManipulationStartedEventArgs e)
+      {
+         base.OnManipulationStarted(e);
+
+         if (MultiTouchEnabled && !TouchEnabled)
+         {
+            Core.mouseDown.X = 0;
+            Core.mouseDown.Y = 0;
+            Core.touchCurrent.X = 0;
+            Core.touchCurrent.Y = 0;
+         }
+      }
+
       /// <summary>
       /// Called when the <see cref="E:System.Windows.UIElement.ManipulationDelta" /> event occurs.
       /// </summary>
@@ -1971,12 +1984,15 @@
       {
          if(MultiTouchEnabled && !TouchEnabled) // redundent check in case this is invoked outside of the manipulation events
          {
-            if(!Core.IsDragging)
-            {
-               deltaPoint = ApplyRotationInversion(deltaPoint.X, deltaPoint.Y);
+            deltaPoint = ApplyRotationInversion(deltaPoint.X, deltaPoint.Y);
 
+            Core.touchCurrent.X += (int)deltaPoint.X;
+            Core.touchCurrent.Y += (int)deltaPoint.Y;
+
+            if (!Core.IsDragging)
+            {
                // cursor has moved beyond drag tolerance
-               if(Math.Abs(deltaPoint.X - Core.mouseDown.X) * 2 >= SystemParameters.MinimumHorizontalDragDistance || Math.Abs(deltaPoint.Y - Core.mouseDown.Y) * 2 >= SystemParameters.MinimumVerticalDragDistance)
+               if(Math.Abs(Core.touchCurrent.X - Core.mouseDown.X) * 2 >= SystemParameters.MinimumHorizontalDragDistance || Math.Abs(Core.touchCurrent.Y - Core.mouseDown.Y) * 2 >= SystemParameters.MinimumVerticalDragDistance)
                {
                   Core.BeginDrag(Core.mouseDown);
                }
@@ -1999,13 +2015,7 @@
                }
                else
                {
-                  deltaPoint = ApplyRotationInversion(deltaPoint.X, deltaPoint.Y);
-
-                  Core.mouseCurrent.X += (int)deltaPoint.X;
-                  Core.mouseCurrent.Y += (int)deltaPoint.Y;
-                  {
-                     Core.Drag(Core.mouseCurrent);
-                  }
+                  Core.Drag(Core.touchCurrent);
 
                   if(IsRotated)
                   {


### PR DESCRIPTION
Previously, there was no handler for OnManipulationStarted, so the Core.mouseDown and Core.mouseCurrent were never initialized for the touch manipulation. This resulted in eg. a sudden movement as soon as a user touched a single finger on the GMapControl.

Added a separate touchCurrent variable for keeping track of the accumulated touch pan operation, to prevent problems if some event changes the mouseCurrent during the touch manipulation operation.

WPF also has separate fields for the accumulated translation, which could simplify the code quite a bit. However, that would mean a breaking change in the interface of SingleTouchPanMap, and I'm not sure how you feel about that. Would you prefer that version?